### PR TITLE
fix: 게시글 작성 시 이미지 파일 인코딩 후 post

### DIFF
--- a/src/pages/Write.tsx
+++ b/src/pages/Write.tsx
@@ -7,24 +7,49 @@ import rightArrowNavy from '../assets/icons/rightArrowNavy.png'
 import pin from '../assets/icons/pin.svg'
 import bedIcon from '../assets/icons/bedIcon.svg'
 import plus from '../assets/icons/plus.svg'
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import Button from '../components/button'
 import Layout from '../layout/Layout'
 import { axiosInstance } from '../api/axios'
 
 export default function Write() {
   //이미지 등록
-  const [images, setImages] = useState<string[]>([])
-  const [imageFiles, setImageFiles] = useState<File[]>([])
+  const [images, setImages] = useState<string[]>([]) //미리보기용
+  const [imageFiles, setImageFiles] = useState<File[]>([]) //image 필드용
+  const [Base64s, setBase64s] = useState<{ url: string }[]>([]) //title에 들어가는 image용
+
+  //이미지 파일 Base64로 인코딩하는 함수
+  const encodeFileToBase64 = (image: File) => {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader()
+      reader.readAsDataURL(image)
+      reader.onload = (event: any) => resolve(event.target.result)
+      reader.onerror = (error) => reject(error)
+    })
+  }
+
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files
     if (files) {
       const fileArray = Array.from(files)
       const imgUrls = fileArray.map((file) => URL.createObjectURL(file))
+
       setImages(imgUrls)
       setImageFiles(fileArray)
     }
   }
+
+  useEffect(() => {
+    if (imageFiles.length > 0) {
+      setBase64s([])
+      imageFiles.forEach((image) => {
+        encodeFileToBase64(image).then((data) =>
+          setBase64s((prev) => [...prev, { url: data as string }])
+        )
+      })
+    }
+  }, [imageFiles])
+  console.log(Base64s)
 
   //이미지 슬라이더
   const [imgIndex, setImgIndex] = useState(0)
@@ -117,7 +142,7 @@ export default function Write() {
     formData.append(
       'title',
       JSON.stringify({
-        images,
+        Base64s,
         writtenTitle,
         tags,
         locations,

--- a/src/pages/Write.tsx
+++ b/src/pages/Write.tsx
@@ -23,7 +23,6 @@ export default function Write() {
       const imgUrls = fileArray.map((file) => URL.createObjectURL(file))
       setImages(imgUrls)
       setImageFiles(fileArray)
-      console.log('선택된 파일들:', fileArray)
     }
   }
 
@@ -134,7 +133,11 @@ export default function Write() {
     formData.append('channelId', selectedChannelId)
 
     try {
-      const res = await axiosInstance.post('/posts/create', formData)
+      const res = await axiosInstance.post('/posts/create', formData, {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      })
       console.log('post 성공:', res.data)
       alert('게시 완료')
     } catch (error) {


### PR DESCRIPTION
## ✅ PR 종류
- [ ] ✨ New Feature (새로운 기능 추가)  
- [ ] 🗑 Remove Feature (기능 삭제)  
- [ ] 🔄 Change Logic (로직 변경)  
- [x] 🐛 Bug Fix (버그 수정)  
- [ ] ♻️ Refactor (리팩토링)  
- [ ] 📝 Documentation (문서 수정)  
- [ ] 🚀 Performance (성능 개선)  
- [ ] ✅ Test (테스트 코드 추가/수정)  
- [ ] 🦄publishing 퍼블리싱


## 🔗 새로 설치한 패키지


## 📌 작업 내용
게시글 작성화면에서 이미지를 업로드 하면 첫번째 이미지는 image 필드에 flie형식으로 들어가고,
첫번째 이미지를 포함한 모든 이미지들은 base64방식으로 인코딩하여 title 필드 안 Base64s에 url 로 넣었습니다.
불러오실 때 이 url을 img태그의 src에 넣으시면 됩니다.

아래 캡쳐본에 보시는 것 처럼 인코딩 된 문자열이 매우매우매우 깁니다. 저 화면은 아주 작은 png파일 두 장을 넣은 것입니다...
API측에서 글자 수 제한(2500자 내외 정도)이 있기 때문에 이미지만으로도 저 정도의 글자 수를 차지하면 별 내용을 못쓸 것 같기는 합니다..

Base64s 형식을 간단하게 보시려면 두번째 캡쳐본 참고해주세요

## 📸 스크린샷 (선택 사항)
![image](https://github.com/user-attachments/assets/840b962a-c1cc-48fb-a5db-0bde0fba5eec)

![image](https://github.com/user-attachments/assets/49f3de1a-47e8-4b3e-961b-131cb3b834f8)

